### PR TITLE
Add methods for "first range check"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.7
+
+* Move `RackResponseWrapper` into the main namespace
+* Add `#satisfied_with_first_interval?` so that certain Range: requests can be served using a redirect
+* Add `#multiple_ranges?` so that one can choose not to honor multipart Range requests
+
+# 0.1.6
+
+* Create a base response type (`Abstract`) which has the same interface as the rest of the responses
+
 # 0.1.5
 
 * Change the API of `IntervalResponse.new` to accept the Rack `env` hash directly, without having the caller extract the header values manually.

--- a/lib/interval_response/abstract.rb
+++ b/lib/interval_response/abstract.rb
@@ -4,6 +4,31 @@ class IntervalResponse::Abstract
     [status_code, headers.to_h.merge(self.headers), IntervalResponse::RackBodyWrapper.new(self, chunk_size: chunk_size)]
   end
 
+  # Tells whether this response is responding with multiple ranges. If you want to simulate S3 for example,
+  # it might be relevant to deny a response from being served if it does respond with multiple ranges -
+  # IntervalResponse supports these responses just fine, but S3 doesn't.
+  def multiple_ranges?
+    false
+  end
+
+  # Tells whether this entire requested range can be satisfied with the first available segment within the given Sequence.
+  # If it is, then you can redirect to the URL of the first segment instead of streaming the response
+  # through - which can be cheaper for your application server. Note that you can redirect to the resource of the first
+  # interval only, because otherwise your `Range` header will no longer match. Suppose you have a stitched resource
+  # consisting of two segments:
+  #
+  #   [bytes 0..456]
+  #   [bytes 457..890]
+  #
+  # and your client requests `Range: bytes=0-33`. You can redirect the client to the location of the first interval,
+  # and the `Range:` header will be retransmitted to that location and will be satisfied. However, imagine you are requesting
+  # the `Range: bytes=510-512` - you _could_ redirect just to the second interval, but the `Range` header is not going to be
+  # adjusted by the client, and you are not going to receive the correct slice of the resource. That's why you can only
+  # redirect to the first interval only.
+  def satisfied_with_first_interval?
+    false
+  end
+
   # @param interval_sequence[IntervalResponse::Sequence] the sequence the response is built for
   def initialize(interval_sequence)
     @interval_sequence = interval_sequence

--- a/lib/interval_response/full.rb
+++ b/lib/interval_response/full.rb
@@ -1,9 +1,12 @@
 # Serves out a response that contains the entire resource
 class IntervalResponse::Full < IntervalResponse::Abstract
+  def initialize(*)
+    super
+    @http_range_for_entire_resource = 0..(@interval_sequence.size - 1)
+  end
+
   def each
-    # serve the part of the interval map
-    full_range = 0..(@interval_sequence.size - 1)
-    @interval_sequence.each_in_range(full_range) do |segment, range_in_segment|
+    @interval_sequence.each_in_range(@http_range_for_entire_resource) do |segment, range_in_segment|
       yield(segment, range_in_segment)
     end
   end
@@ -14,6 +17,14 @@ class IntervalResponse::Full < IntervalResponse::Abstract
 
   def content_length
     @interval_sequence.size
+  end
+
+  def satisfied_with_first_interval?
+    @interval_sequence.first_interval_only?(@http_range_for_entire_resource)
+  end
+
+  def multiple_ranges?
+    false
   end
 
   def headers

--- a/lib/interval_response/multi.rb
+++ b/lib/interval_response/multi.rb
@@ -47,6 +47,14 @@ class IntervalResponse::Multi < IntervalResponse::Abstract
     }
   end
 
+  def satisfied_with_first_interval?
+    @interval_sequence.first_interval_only?(*@http_ranges)
+  end
+
+  def multiple_ranges?
+    true
+  end
+
   private
 
   def compute_envelope_size

--- a/lib/interval_response/single.rb
+++ b/lib/interval_response/single.rb
@@ -32,4 +32,8 @@ class IntervalResponse::Single < IntervalResponse::Abstract
       'ETag' => etag,
     }
   end
+
+  def satisfied_with_first_interval?
+    @interval_sequence.first_interval_only?(@http_range)
+  end
 end

--- a/lib/interval_response/version.rb
+++ b/lib/interval_response/version.rb
@@ -1,3 +1,3 @@
 module IntervalResponse
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
Sometimes we may be able to redirect to the resource covered by the first HTTP range that is requested. To
do so, specifically on S3, two conditions must be satisfied:

* The request must be for a single range or for the entire resource - not a multipart (multi-range) request
* The request must be using content from the first interval only - so that we can redirect and have the HTTP client
  retransmit the same HTTP `Range` request to the location of the first interval

This adds methods for implementing both - additionally, if the upstream supports miltirange responses we can
redirect with them as well.

To use it, one can do the following:

```ruby
response = IntervalResponse.new(interval_sequence, env)
if response.satisfied_with_first_interval?
  [302, {"Location" => first_interval.url}, []]
else
  response.to_rack_response_triplet
end
```